### PR TITLE
Local objects in custom emulators

### DIFF
--- a/R/ProtoEmulatorDocumentation.R
+++ b/R/ProtoEmulatorDocumentation.R
@@ -26,18 +26,18 @@
 #'
 #'
 #'    \code{predict_func} The function that provides the predictions at a new
-#'    point. This should be a function that takes one argument, \code{x}, which
+#'    point. This should be a function with first argument, \code{x}, which
 #'    can be a single point or a data.frame of points.
 #'
 #'    \code{variance_func} The function that encodes the prediction error due to
-#'    the model of choice. This, too, takes an argument \code{x} of the same form
+#'    the model of choice. This, too, takes a first argument \code{x} of the same form
 #'    as that of \code{predict_func}.
 #'
 #'    Optional:
 #'
 #'    \code{implausibility_func} A function that takes points \code{x} and a
-#'    target \code{z} (and possibly a cutoff value \code{cutoff}) and returns
-#'    a measure of closeness of the predicted value to the target (or a boolean
+#'    target \code{z} (and possibly a cutoff value \code{cutoff} and additional arguments) 
+#'    and returns a measure of closeness of the predicted value to the target (or a boolean
 #'    representing whether the prediction is within the specified amount).
 #'    If not provided, then the standard implausibility is used: namely the
 #'    absolute value of the prediction minus the observation, dividied by the
@@ -45,6 +45,9 @@
 #'
 #'    \code{print_func} If the prediction object has a suitable print function
 #'    that one wishes to transfer to the R6 class, it is specified here.
+#'
+#'    \code{...} Additional objects to pass to emulators and/or implausibility
+#'    measures.
 #'
 #' @section Constructor Details:
 #'

--- a/man/Proto_emulator.Rd
+++ b/man/Proto_emulator.Rd
@@ -26,18 +26,18 @@ Converts a prediction object into a form amenable to hmer.
 
 
    \code{predict_func} The function that provides the predictions at a new
-   point. This should be a function that takes one argument, \code{x}, which
+   point. This should be a function with first argument, \code{x}, which
    can be a single point or a data.frame of points.
 
    \code{variance_func} The function that encodes the prediction error due to
-   the model of choice. This, too, takes an argument \code{x} of the same form
+   the model of choice. This, too, takes a first argument \code{x} of the same form
    as that of \code{predict_func}.
 
    Optional:
 
    \code{implausibility_func} A function that takes points \code{x} and a
-   target \code{z} (and possibly a cutoff value \code{cutoff}) and returns
-   a measure of closeness of the predicted value to the target (or a boolean
+   target \code{z} (and possibly a cutoff value \code{cutoff} and additional arguments) 
+   and returns a measure of closeness of the predicted value to the target (or a boolean
    representing whether the prediction is within the specified amount).
    If not provided, then the standard implausibility is used: namely the
    absolute value of the prediction minus the observation, dividied by the
@@ -45,6 +45,9 @@ Converts a prediction object into a form amenable to hmer.
 
    \code{print_func} If the prediction object has a suitable print function
    that one wishes to transfer to the R6 class, it is specified here.
+
+   \code{...} Additional objects to pass to emulators and/or implausibility
+   measures.
 }
 
 \section{Constructor Details}{


### PR DESCRIPTION
Hey man,

Here is an attempt to allow additional arguments to be included in custom emulator and implausibility functions.

I've attached a reprex below. The only issue that still remains is the change of `cutoff` when sampling new points. I currently amend L496 of `genpoints.R` to read:

```
cutoff_current <- cutoff
```
but I'm not sure if this has any further consequences? 

[wave1.zip](https://github.com/andy-iskauskas/hmer/files/10245902/wave1.zip)

The downside of this is that you can't use the `self$` reference in your custom implausibility function (in the same way that you can't for the custom `predf` and `varf` functions either). In the attached example I fit a GP, and then include this as an additional object `em` when `Proto_emulator()` is run. All additional arguments to any function passed to `Proto_emulator()` must then be passed in as additional arguments when building the custom emulator, and these are all checked each time one of these functions is run (so should throw an error if some arguments are missing).

See what you think?

Cheers,

T

P.S. I haven't updated the examples in the documentation - I only made rudimentary changes.