### PR TITLE
Some plotting suggestions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,10 +37,11 @@ Imports:
   rlang,
   isoband,
   cluster,
-  pdist
+  pdist,
+  ggbeeswarm
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Language: en-GB
 Config/testthat/edition: 3

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -515,6 +515,7 @@ output_plot <- function(ems, targets, points = NULL, npoints = 1000) {
 #' @param maxpoints The limit on the number of points to be evaluated.
 #' @param imp_breaks If plotting nth maximum implausibility, defines the levels at
 #'                   which to draw contours.
+#' @param contour Logical determining whether to plot implausibility contours or not.
 #'
 #' @return A ggplot object
 #'
@@ -529,7 +530,8 @@ output_plot <- function(ems, targets, points = NULL, npoints = 1000) {
 #'  plot_lattice(SIREmulators$ems$nS, SIREmulators$targets)
 #' }
 plot_lattice <- function(ems, targets, ppd = 20, cb = FALSE,
-                         cutoff = 3, maxpoints = 5e4, imp_breaks = NULL) {
+                         cutoff = 3, maxpoints = 5e4, imp_breaks = NULL, 
+                         contour = TRUE) {
   ems <- collect_emulators(ems)
   ranges <- if ("Emulator" %in% class(ems)) ems$ranges else ems[[1]]$ranges
   if (ppd^length(ranges) > maxpoints) {
@@ -619,7 +621,7 @@ plot_lattice <- function(ems, targets, ppd = 20, cb = FALSE,
       which(names(ranges) == parameters[2])) {
       pt <- two_dim(point_grid, parameters)
       g <- ggplot(mapping = aes(x = pt[,1], y = pt[,2], z = pt[,3])) +
-        geom_contour_filled(breaks = imp_breaks, colour = 'black') +
+        geom_contour_filled(breaks = imp_breaks, colour = ifelse(contour, "black", NA)) +
         scale_fill_manual(values = cols, labels = imp_names,
                           name = "Min. I",
                           guide = guide_legend(reverse = TRUE), drop = FALSE) +

--- a/man/plot_lattice.Rd
+++ b/man/plot_lattice.Rd
@@ -11,7 +11,8 @@ plot_lattice(
   cb = FALSE,
   cutoff = 3,
   maxpoints = 50000,
-  imp_breaks = NULL
+  imp_breaks = NULL,
+  contour = TRUE
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ plot_lattice(
 
 \item{imp_breaks}{If plotting nth maximum implausibility, defines the levels at
 which to draw contours.}
+
+\item{contour}{Logical determining whether to plot implausibility contours or not.}
 }
 \value{
 A ggplot object


### PR DESCRIPTION
Here there are two commits, the first relates to the fact that `simulator_plot()` fails if you only have a single output. The `drop = FALSE` part fixes the pivot (else it returns a pivoted table with nonsensical output names). Then I've added a prototype beeswarm plot for examining the evolution of a single output across waves. I tried a few things, but this seemed to work better. It adds another dependency package (`ggbeeswarm`). See what you think.

The second adds a `contour` argument to `plot_lattice()`, which allows the user to remove the black contour lines from the minimum implausibility plot if required. This is because for e.g. narrow regions of non-implausibility the contour plots obscure the underlying colours and hence you can't make out the region clearly, so this adds a simple `TRUE`/`FALSE` option to plot this or not.

I haven't added this to any other plot functions (such as `emulator_plot()`, but one could do). Again, feel free to take these suggestions or not as you see fit.

Cheers, T